### PR TITLE
Corrige campos co_op y solo en GameData para PyPI v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/),
 y este proyecto adhiere al [Versionado Semántico](https://semver.org/lang/es/).
 
+## [1.1.2] - 2024-10-08
+
+### Corregido
+- **HOTFIX**: Corregida la clase `GameData` en PyPI para incluir los campos `co_op` y `solo`
+- La versión 1.1.1 en PyPI no incluía correctamente estos campos nuevos
+- Ahora la clase `GameData` expone correctamente todos los atributos: `title`, `main_story`, `main_extra`, `completionist`, `solo`, `co_op`
+
+### Notas técnicas
+- Esta es una corrección crítica para usuarios que dependen de los campos Co-Op y Solo
+- No hay cambios funcionales, solo corrección del empaquetado
+
 ## [1.1.1] - 2024-12-19
 
 ### Corregido

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "howlongtobeat-scraper"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     {name = "Sermodi", email = "sermodsoftware@gmail.com"},
 ]

--- a/src/howlongtobeat_scraper/__init__.py
+++ b/src/howlongtobeat_scraper/__init__.py
@@ -17,7 +17,7 @@ from .api import (
     get_game_stats_smart,
 )
 
-__version__ = "1.1.0"
+__version__ = "1.1.2"
 __author__ = "Sermodi"
 __email__ = "sermodsoftware@gmail.com"
 


### PR DESCRIPTION
Cambios:
- Incrementa versión a 1.1.2 en pyproject.toml y __init__.py
- Actualiza CHANGELOG.md con corrección crítica
- Regenera paquete con campos co_op y solo correctamente incluidos

Motivación/Contexto:
- La versión 1.1.1 en PyPI no incluía los campos co_op y solo en GameData
- Usuarios reportaron campos faltantes en la clase instalada desde PyPI
- Hotfix crítico para mantener compatibilidad con APIs que dependen de estos campos

Implementación:
- Verifica que GameData incluye todos los campos: title, main_story, main_extra, completionist, solo, co_op
- Limpia y regenera distribución con build y twine check
- Sube versión corregida a PyPI oficial

Pruebas:
- Tests unitarios pasan (38 passed, 2 skipped)
- Verificación funcional con 'It Takes Two' (co_op: 14)
- Verificación de campos en clase instalada desde PyPI
- CLI funciona correctamente

Refs:
- Hotfix para issue de campos faltantes en PyPI